### PR TITLE
Fix Travis Clang build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ os: linux
 env:
   - BUILD_TYPE=Debug EXTRA_CHECKS=ON TRACE=ON CXX_=g++-6 CC_=gcc-6 GR_BACKEND=GL
   - BUILD_TYPE=Release EXTRA_CHECKS=OFF TRACE=OFF CXX_=g++-6 CC_=gcc-6 GR_BACKEND=GL
-  - BUILD_TYPE=Debug EXTRA_CHECKS=ON TRACE=ON CXX_=clang++-3.7 CC_=clang-3.7 GR_BACKEND=GL
-  - BUILD_TYPE=Release EXTRA_CHECKS=OFF TRACE=OFF CXX_=clang++-3.7 CC_=clang-3.7 GR_BACKEND=GL
+  - BUILD_TYPE=Debug EXTRA_CHECKS=ON TRACE=ON CXX_=clang++-4.0 CC_=clang-4.0 GR_BACKEND=GL
+  - BUILD_TYPE=Release EXTRA_CHECKS=OFF TRACE=OFF CXX_=clang++-4.0 CC_=clang-4.0 GR_BACKEND=GL
   - BUILD_TYPE=Debug EXTRA_CHECKS=ON TRACE=ON CXX_=g++-6 CC_=gcc-6 GR_BACKEND=VULKAN
-  - BUILD_TYPE=Debug EXTRA_CHECKS=ON TRACE=ON CXX_=clang++-3.7 CC_=clang-3.7 GR_BACKEND=VULKAN
+  - BUILD_TYPE=Debug EXTRA_CHECKS=ON TRACE=ON CXX_=clang++-4.0 CC_=clang-4.0 GR_BACKEND=VULKAN
 
 cache:
   apt: true
@@ -19,12 +19,13 @@ cache:
 addons:
   apt:
     sources:
+      - llvm-toolchain-trusty-4.0
       - sourceline: 'ppa:ubuntu-toolchain-r/test'
       - sourceline: 'ppa:graphics-drivers/ppa'
     packages:
       - cmake
       - g++-6
-      - clang-3.5
+      - clang-4.0
       - libvulkan-dev
       - libegl1-mesa-dev
 


### PR DESCRIPTION
Use Clang 4.0 when building with Travis. This is the oldest available clang version on the official llvm apt repositories. I could't find any ppa with Clang 3.7. This means we can't guarantee 3.7 works since we aren't testing it, but at least Travis builds work at all now (and we can guarantee Clang 4.0+ support).