### PR TITLE
Multiple workarounds to support Adreno

### DIFF
--- a/AnKi/Gr/Common.h
+++ b/AnKi/Gr/Common.h
@@ -138,6 +138,10 @@ public:
 	/// Max push constant size.
 	PtrSize m_pushConstantsSize = 128;
 
+	/// The max combined size of shared variables (with paddings) in compute
+	/// shaders.
+	PtrSize m_computeSharedMemorySize = 16384;
+
 	/// Each SBT record should be a multiple of this.
 	U32 m_sbtRecordAlignment = MAX_U32;
 
@@ -173,7 +177,7 @@ public:
 };
 ANKI_END_PACKED_STRUCT
 static_assert(sizeof(GpuDeviceCapabilities)
-				  == sizeof(PtrSize) * 4 + sizeof(U32) * 5 + sizeof(U8) * 3 + sizeof(Bool) * 6,
+				  == sizeof(PtrSize) * 5 + sizeof(U32) * 5 + sizeof(U8) * 3 + sizeof(Bool) * 6,
 			  "Should be packed");
 
 /// The type of the allocator for heap allocations

--- a/AnKi/Gr/Vulkan/GrManagerImpl.cpp
+++ b/AnKi/Gr/Vulkan/GrManagerImpl.cpp
@@ -510,6 +510,7 @@ Error GrManagerImpl::initInstance(const GrManagerInitInfo& init)
 	m_capabilities.m_textureBufferBindOffsetAlignment =
 		max<U32>(ANKI_SAFE_ALIGNMENT, U32(m_devProps.properties.limits.minTexelBufferOffsetAlignment));
 	m_capabilities.m_textureBufferMaxRange = MAX_U32;
+	m_capabilities.m_computeSharedMemorySize = U32(m_devProps.properties.limits.maxComputeSharedMemorySize);
 
 	m_capabilities.m_majorApiVersion = vulkanMajor;
 	m_capabilities.m_minorApiVersion = vulkanMinor;

--- a/AnKi/Gr/Vulkan/GrManagerImpl.h
+++ b/AnKi/Gr/Vulkan/GrManagerImpl.h
@@ -172,6 +172,11 @@ public:
 	}
 #endif
 
+	Mutex& getPipelineGlobalLock()
+	{
+		return m_pipelineMtx;
+	}
+
 	/// @name Debug report
 	/// @{
 	void beginMarker(VkCommandBuffer cmdb, CString name) const
@@ -259,6 +264,7 @@ private:
 	PFN_vkGetShaderInfoAMD m_pfnGetShaderInfoAMD = nullptr;
 	mutable File m_shaderStatsFile;
 	mutable SpinLock m_shaderStatsFileMtx;
+	Mutex m_pipelineMtx;
 
 	/// @name Surface_related
 	/// @{

--- a/AnKi/Gr/Vulkan/Pipeline.cpp
+++ b/AnKi/Gr/Vulkan/Pipeline.cpp
@@ -469,6 +469,8 @@ void PipelineFactory::getOrCreatePipeline(PipelineStateTracker& state, Pipeline&
 
 	{
 		ANKI_TRACE_SCOPED_EVENT(VK_PIPELINE_CREATE);
+		static Mutex sync;
+		LockGuard<Mutex> guard(sync);
 		ANKI_VK_CHECKF(vkCreateGraphicsPipelines(m_dev, m_pplineCache, 1, &ci, nullptr, &pp.m_handle));
 	}
 

--- a/AnKi/Gr/Vulkan/Pipeline.cpp
+++ b/AnKi/Gr/Vulkan/Pipeline.cpp
@@ -469,8 +469,6 @@ void PipelineFactory::getOrCreatePipeline(PipelineStateTracker& state, Pipeline&
 
 	{
 		ANKI_TRACE_SCOPED_EVENT(VK_PIPELINE_CREATE);
-		static Mutex sync;
-		LockGuard<Mutex> guard(sync);
 		ANKI_VK_CHECKF(vkCreateGraphicsPipelines(m_dev, m_pplineCache, 1, &ci, nullptr, &pp.m_handle));
 	}
 

--- a/AnKi/Gr/Vulkan/Pipeline.h
+++ b/AnKi/Gr/Vulkan/Pipeline.h
@@ -549,12 +549,7 @@ public:
 	{
 	}
 
-	void init(GrAllocator<U8> alloc, VkDevice dev, VkPipelineCache pplineCache)
-	{
-		m_alloc = alloc;
-		m_dev = dev;
-		m_pplineCache = pplineCache;
-	}
+	void init(GrManagerImpl *gr);
 
 	void destroy();
 
@@ -571,6 +566,9 @@ private:
 
 	HashMap<U64, PipelineInternal, Hasher> m_pplines;
 	RWMutex m_pplinesMtx;
+#if ANKI_PLATFORM_MOBILE
+	Mutex* m_pplinesGlobalMtxPtr = nullptr;
+#endif
 };
 /// @}
 

--- a/AnKi/Gr/Vulkan/ShaderProgramImpl.cpp
+++ b/AnKi/Gr/Vulkan/ShaderProgramImpl.cpp
@@ -221,8 +221,7 @@ Error ShaderProgramImpl::init(const ShaderProgramInitInfo& inf)
 	if(graphicsProg)
 	{
 		m_graphics.m_pplineFactory = getAllocator().newInstance<PipelineFactory>();
-		m_graphics.m_pplineFactory->init(getGrManagerImpl().getAllocator(), getGrManagerImpl().getDevice(),
-										 getGrManagerImpl().getPipelineCache());
+		m_graphics.m_pplineFactory->init(&getGrManagerImpl());
 	}
 
 	// Create the pipeline if compute

--- a/AnKi/Renderer/IndirectDiffuseProbes.h
+++ b/AnKi/Renderer/IndirectDiffuseProbes.h
@@ -99,6 +99,7 @@ private:
 	HashMap<U64, U32> m_probeUuidToCacheEntryIdx;
 	U32 m_tileSize = 0;
 	U32 m_maxVisibleProbes = 0;
+	Bool m_useSharedSsbo = false;
 
 	ANKI_USE_RESULT Error initInternal();
 	ANKI_USE_RESULT Error initGBuffer();

--- a/AnKi/Renderer/ProbeReflections.cpp
+++ b/AnKi/Renderer/ProbeReflections.cpp
@@ -139,6 +139,9 @@ Error ProbeReflections::initLightShading()
 Error ProbeReflections::initIrradiance()
 {
 	m_irradiance.m_workgroupSize = getConfig().getRProbeReflectionIrradianceResolution();
+	m_irradiance.m_useSharedSsbo =
+		(getGrManager().getDeviceCapabilities().m_computeSharedMemorySize
+		 < sizeof(Vec4) * 6 * U32(m_irradiance.m_workgroupSize) * U32(m_irradiance.m_workgroupSize) + sizeof(Vec4) * 6);
 
 	// Create prog
 	{
@@ -150,6 +153,7 @@ Error ProbeReflections::initIrradiance()
 		variantInitInfo.addMutation("LIGHT_SHADING_TEX", 1);
 		variantInitInfo.addMutation("STORE_LOCATION", 1);
 		variantInitInfo.addMutation("SECOND_BOUNCE", 0);
+		variantInitInfo.addMutation("SHARED_SSBO", m_irradiance.m_useSharedSsbo);
 
 		const ShaderProgramResourceVariant* variant;
 		m_irradiance.m_prog->getOrCreateVariant(variantInitInfo, variant);

--- a/AnKi/Renderer/ProbeReflections.h
+++ b/AnKi/Renderer/ProbeReflections.h
@@ -82,6 +82,7 @@ private:
 		ShaderProgramPtr m_grProg;
 		BufferPtr m_diceValuesBuff;
 		U32 m_workgroupSize = 16;
+		Bool m_useSharedSsbo = false;
 	} m_irradiance; ///< Irradiance.
 
 	class

--- a/AnKi/Shaders/ClusterBinning.ankiprog
+++ b/AnKi/Shaders/ClusterBinning.ankiprog
@@ -28,7 +28,7 @@ layout(set = 0, binding = 1, scalar) writeonly buffer b_clusters
 	Cluster u_clusters[];
 };
 
-layout(set = 0, binding = 2, scalar) uniform b_pointLights
+layout(set = 0, binding = 2, std430) uniform b_pointLights
 {
 	PointLight u_pointLights[MAX_VISIBLE_POINT_LIGHTS];
 };
@@ -38,12 +38,12 @@ layout(set = 0, binding = 3, scalar) uniform b_spotLights
 	SpotLightBinning u_spotLights[MAX_VISIBLE_SPOT_LIGHTS];
 };
 
-layout(set = 0, binding = 4, scalar) uniform b_reflectionProbes
+layout(set = 0, binding = 4, std430) uniform b_reflectionProbes
 {
 	ReflectionProbe u_reflectionProbes[MAX_VISIBLE_REFLECTION_PROBES];
 };
 
-layout(set = 0, binding = 5, scalar) uniform b_giProbes
+layout(set = 0, binding = 5, std430) uniform b_giProbes
 {
 	GlobalIlluminationProbe u_giProbes[MAX_VISIBLE_GLOBAL_ILLUMINATION_PROBES];
 };

--- a/AnKi/Shaders/ClusteredShadingCommon.glsl
+++ b/AnKi/Shaders/ClusteredShadingCommon.glsl
@@ -21,7 +21,7 @@ layout(set = CLUSTERED_SHADING_SET, binding = CLUSTERED_SHADING_UNIFORMS_BINDING
 // Light uniforms (3)
 //
 #if defined(CLUSTERED_SHADING_LIGHTS_BINDING)
-layout(set = CLUSTERED_SHADING_SET, binding = CLUSTERED_SHADING_LIGHTS_BINDING, scalar) uniform b_pointLights
+layout(set = CLUSTERED_SHADING_SET, binding = CLUSTERED_SHADING_LIGHTS_BINDING, std430) uniform b_pointLights
 {
 	PointLight u_pointLights2[MAX_VISIBLE_POINT_LIGHTS];
 };

--- a/AnKi/Shaders/GBufferGeneric.ankiprog
+++ b/AnKi/Shaders/GBufferGeneric.ankiprog
@@ -128,7 +128,7 @@ layout(set = 0, binding = 0, row_major, scalar) uniform b_ankiPerDraw
 #endif
 
 #pragma anki reflect b_ankiPerInstance
-layout(set = 0, binding = 1, row_major, scalar) uniform b_ankiPerInstance
+layout(set = 0, binding = 1, row_major, std430) uniform b_ankiPerInstance
 {
 	PerInstance u_ankiPerInstance[MAX_INSTANCE_COUNT];
 };

--- a/AnKi/Shaders/Include/ClusteredShadingTypes.h
+++ b/AnKi/Shaders/Include/ClusteredShadingTypes.h
@@ -155,9 +155,9 @@ struct GlobalIlluminationProbe
 
 	/// Used to calculate a factor that is zero when fragPos is close to AABB bounds and 1.0 at fadeDistance and less.
 	ANKI_RP F32 m_fadeDistance;
-	F32 m_padding0;
+	Vec3 m_padding0;
 };
-const U32 _ANKI_SIZEOF_GlobalIlluminationProbe = 10u * ANKI_SIZEOF(U32);
+const U32 _ANKI_SIZEOF_GlobalIlluminationProbe = 12u * ANKI_SIZEOF(U32);
 ANKI_SHADER_STATIC_ASSERT(sizeof(GlobalIlluminationProbe) == _ANKI_SIZEOF_GlobalIlluminationProbe);
 
 /// Common matrices.

--- a/AnKi/Shaders/Include/ClusteredShadingTypes.h
+++ b/AnKi/Shaders/Include/ClusteredShadingTypes.h
@@ -43,14 +43,15 @@ const ANKI_RP F32 SUBSURFACE_MIN = 0.01f;
 struct PointLight
 {
 	Vec3 m_position; ///< Position in world space.
-	ANKI_RP Vec3 m_diffuseColor;
 	ANKI_RP F32 m_radius; ///< Radius
+	ANKI_RP Vec3 m_diffuseColor;
 	ANKI_RP F32 m_squareRadiusOverOne; ///< 1/(radius^2).
 	U32 m_shadowLayer; ///< Shadow layer used in RT shadows. Also used to show that it doesn't cast shadow.
 	F32 m_shadowAtlasTileScale; ///< UV scale for all tiles.
+	Vec2 m_padding0;
 	Vec2 m_shadowAtlasTileOffsets[6u];
 };
-const U32 _ANKI_SIZEOF_PointLight = 22u * ANKI_SIZEOF(U32);
+const U32 _ANKI_SIZEOF_PointLight = 24u * ANKI_SIZEOF(U32);
 ANKI_SHADER_STATIC_ASSERT(sizeof(PointLight) == _ANKI_SIZEOF_PointLight);
 
 /// Spot light.
@@ -75,11 +76,11 @@ ANKI_SHADER_STATIC_ASSERT(sizeof(SpotLight) == _ANKI_SIZEOF_SpotLight);
 struct SpotLightBinning
 {
 	Vec3 m_edgePoints[5u]; ///< Edge points in world space.
-	ANKI_RP Vec3 m_diffuseColor;
 	ANKI_RP F32 m_radius; ///< Max distance.
+	ANKI_RP Vec3 m_diffuseColor;
 	ANKI_RP F32 m_squareRadiusOverOne; ///< 1/(radius^2).
-	U32 m_shadowLayer; ///< Shadow layer used in RT shadows. Also used to show that it doesn't cast shadow.
 	ANKI_RP Vec3 m_direction; ///< Light direction.
+	U32 m_shadowLayer; ///< Shadow layer used in RT shadows. Also used to show that it doesn't cast shadow.
 	ANKI_RP F32 m_outerCos;
 	ANKI_RP F32 m_innerCos;
 	Vec2 m_padding;
@@ -111,9 +112,11 @@ struct ReflectionProbe
 	Vec3 m_position; ///< Position of the probe in world space.
 	F32 m_cubemapIndex; ///< Index in the cubemap array texture.
 	Vec3 m_aabbMin;
+	F32 m_padding0;
 	Vec3 m_aabbMax;
+	F32 m_padding1;
 };
-const U32 _ANKI_SIZEOF_ReflectionProbe = 10u * ANKI_SIZEOF(U32);
+const U32 _ANKI_SIZEOF_ReflectionProbe = 12u * ANKI_SIZEOF(U32);
 ANKI_SHADER_STATIC_ASSERT(sizeof(ReflectionProbe) == _ANKI_SIZEOF_ReflectionProbe);
 
 /// Decal.
@@ -145,15 +148,16 @@ ANKI_SHADER_STATIC_ASSERT(sizeof(FogDensityVolume) == _ANKI_SIZEOF_FogDensityVol
 struct GlobalIlluminationProbe
 {
 	Vec3 m_aabbMin;
-	Vec3 m_aabbMax;
-
-	U32 m_textureIndex; ///< Index to the array of volume textures.
 	F32 m_halfTexelSizeU; ///< (1.0 / textureSize(texArr[textureIndex]).x) / 2.0
+
+	Vec3 m_aabbMax;
+	U32 m_textureIndex; ///< Index to the array of volume textures.
 
 	/// Used to calculate a factor that is zero when fragPos is close to AABB bounds and 1.0 at fadeDistance and less.
 	ANKI_RP F32 m_fadeDistance;
+	F32 m_padding0;
 };
-const U32 _ANKI_SIZEOF_GlobalIlluminationProbe = 9u * ANKI_SIZEOF(U32);
+const U32 _ANKI_SIZEOF_GlobalIlluminationProbe = 10u * ANKI_SIZEOF(U32);
 ANKI_SHADER_STATIC_ASSERT(sizeof(GlobalIlluminationProbe) == _ANKI_SIZEOF_GlobalIlluminationProbe);
 
 /// Common matrices.

--- a/AnKi/Shaders/IrradianceDice.ankiprog
+++ b/AnKi/Shaders/IrradianceDice.ankiprog
@@ -9,6 +9,7 @@
 #pragma anki mutator LIGHT_SHADING_TEX 0 1 // 0: texture2D, 1: textureCubeArray
 #pragma anki mutator STORE_LOCATION 0 1 // 0: in a 3D texture, 1: In an SSBO
 #pragma anki mutator SECOND_BOUNCE 0 1
+#pragma anki mutator SHARED_SSBO 0 1 // 0: in a shared memory, 1: In an SSBO
 
 #pragma anki start comp
 
@@ -34,10 +35,14 @@ layout(set = 0, binding = 2) uniform texture2D u_gbufferTex[3u];
 #endif
 
 // This is a temporary buffer used instead of shared memory because we can't fit it into shared memory
+#if SHARED_SSBO == 1
 layout(set = 0, binding = 3, std430) buffer ssbo_
 {
 	Vec4 u_integrationResults[6u * WORKGROUP_SIZE];
 };
+#else
+shared Vec4 u_integrationResults[6u * WORKGROUP_SIZE];
+#endif
 
 #if STORE_LOCATION == 0
 layout(set = 0, binding = 4) uniform writeonly image3D u_irradianceVolume;


### PR DESCRIPTION
1. Use std430 layout instead scalar for arrayed data
2. Use shared memory instead of global rw-ssbo in Irradiance shader