### PR TITLE
Split WindowFullscreen flag into WindowFullscreen + FullscreenExclusive

### DIFF
--- a/AnKi/Core/App.cpp
+++ b/AnKi/Core/App.cpp
@@ -240,7 +240,7 @@ Error App::initInternal(AllocAlignedCallback allocCb, void* allocCbUserData)
 	nwinit.m_height = m_config->getHeight();
 	nwinit.m_depthBits = 0;
 	nwinit.m_stencilBits = 0;
-	nwinit.m_fullscreenDesktopRez = m_config->getWindowFullscreen();
+	nwinit.m_fullscreenDesktopRez = NativeWindowInitInfo::WindowMode(m_config->getWindowFullscreen());
 	ANKI_CHECK(NativeWindow::newInstance(nwinit, m_window));
 
 	//

--- a/AnKi/Core/ConfigVars.defs.h
+++ b/AnKi/Core/ConfigVars.defs.h
@@ -15,8 +15,7 @@ ANKI_CONFIG_VAR_BOOL(CoreMaliHwCounters, false, "Enable Mali counters")
 
 ANKI_CONFIG_VAR_U32(Width, 1920, 16, 16 * 1024, "Width")
 ANKI_CONFIG_VAR_U32(Height, 1080, 16, 16 * 1024, "Height")
-ANKI_CONFIG_VAR_BOOL(WindowFullscreen, false, "Start at fullscreen")
-ANKI_CONFIG_VAR_BOOL(FullscreenExclusive, false, "Use exclusive mode, while at fullscreen")
+ANKI_CONFIG_VAR_U32(WindowFullscreen, 1, 0, 2, "Start at fullscreen")
 
 ANKI_CONFIG_VAR_U32(CoreTargetFps, 60u, 30u, MAX_U32, "Target FPS")
 ANKI_CONFIG_VAR_U32(CoreJobThreadCount, max(2u, getCpuCoresCount() / 2u), 2u, 1024u, "Number of job thread")

--- a/AnKi/Core/ConfigVars.defs.h
+++ b/AnKi/Core/ConfigVars.defs.h
@@ -16,6 +16,7 @@ ANKI_CONFIG_VAR_BOOL(CoreMaliHwCounters, false, "Enable Mali counters")
 ANKI_CONFIG_VAR_U32(Width, 1920, 16, 16 * 1024, "Width")
 ANKI_CONFIG_VAR_U32(Height, 1080, 16, 16 * 1024, "Height")
 ANKI_CONFIG_VAR_BOOL(WindowFullscreen, false, "Start at fullscreen")
+ANKI_CONFIG_VAR_BOOL(FullscreenExclusive, false, "Use exclusive mode, while at fullscreen")
 
 ANKI_CONFIG_VAR_U32(CoreTargetFps, 60u, 30u, MAX_U32, "Target FPS")
 ANKI_CONFIG_VAR_U32(CoreJobThreadCount, max(2u, getCpuCoresCount() / 2u), 2u, 1024u, "Number of job thread")

--- a/AnKi/Core/NativeWindow.h
+++ b/AnKi/Core/NativeWindow.h
@@ -29,6 +29,7 @@ public:
 	static const Bool m_doubleBuffer = true;
 	/// Create a fullscreen window with the desktop's resolution
 	Bool m_fullscreenDesktopRez = false;
+	Bool m_exclusiveMode = false;
 
 	CString m_title = "AnKi";
 };

--- a/AnKi/Core/NativeWindow.h
+++ b/AnKi/Core/NativeWindow.h
@@ -17,6 +17,12 @@ namespace anki {
 class NativeWindowInitInfo
 {
 public:
+	enum class WindowMode : U8
+	{
+		Windowed = 0,
+		Fullscreen = 1,
+		FullscreenExclusive = 2
+	};
 	AllocAlignedCallback m_allocCallback = nullptr;
 	void* m_allocCallbackUserData = nullptr;
 
@@ -28,8 +34,7 @@ public:
 	U32 m_samplesCount = 0;
 	static const Bool m_doubleBuffer = true;
 	/// Create a fullscreen window with the desktop's resolution
-	Bool m_fullscreenDesktopRez = false;
-	Bool m_exclusiveMode = false;
+	WindowMode m_fullscreenDesktopRez = WindowMode::Windowed;
 
 	CString m_title = "AnKi";
 };

--- a/AnKi/Core/NativeWindowSdl.cpp
+++ b/AnKi/Core/NativeWindowSdl.cpp
@@ -104,9 +104,14 @@ Error NativeWindowSdl::init(const NativeWindowInitInfo& init)
 	flags |= SDL_WINDOW_VULKAN;
 #endif
 
-	if(init.m_fullscreenDesktopRez)
+	SDL_SetHint(SDL_HINT_ALLOW_TOPMOST, "0");
+	if(init.m_exclusiveMode)
 	{
 		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+	}
+
+	if(init.m_fullscreenDesktopRez)
+	{
 
 		// Alter the window size
 		SDL_DisplayMode mode;

--- a/AnKi/Core/NativeWindowSdl.cpp
+++ b/AnKi/Core/NativeWindowSdl.cpp
@@ -105,13 +105,12 @@ Error NativeWindowSdl::init(const NativeWindowInitInfo& init)
 #endif
 
 	SDL_SetHint(SDL_HINT_ALLOW_TOPMOST, "0");
-	if(init.m_exclusiveMode)
+	if(init.m_fullscreenDesktopRez != NativeWindowInitInfo::WindowMode::Windowed)
 	{
-		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-	}
-
-	if(init.m_fullscreenDesktopRez)
-	{
+		if(init.m_fullscreenDesktopRez == NativeWindowInitInfo::WindowMode::FullscreenExclusive)
+		{
+			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+		}
 
 		// Alter the window size
 		SDL_DisplayMode mode;


### PR DESCRIPTION
This change should simplify debugging on Windows machines: even if app crashes keyboard and mouse won't be blocked.