### PR TITLE
VRS mip bias

### DIFF
--- a/AnKi/Renderer/Dbg.cpp
+++ b/AnKi/Renderer/Dbg.cpp
@@ -72,7 +72,7 @@ void Dbg::run(RenderPassWorkContext& rgraphCtx, const RenderingContext& ctx)
 	dctx.m_frameAllocator = ctx.m_tempAllocator;
 	dctx.m_commandBuffer = cmdb;
 	dctx.m_sampler = m_r->getSamplers().m_trilinearRepeatAniso;
-	dctx.m_key = RenderingKey(Pass::FS, 0, 1, false, false);
+	dctx.m_key = RenderingKey(Pass::FS, 0, 1, false, false, false);
 	dctx.m_debugDraw = true;
 	dctx.m_debugDrawFlags = m_debugDrawFlags;
 

--- a/AnKi/Renderer/Drawer.cpp
+++ b/AnKi/Renderer/Drawer.cpp
@@ -41,7 +41,7 @@ RenderableDrawer::~RenderableDrawer()
 
 void RenderableDrawer::drawRange(Pass pass, const Mat4& viewMat, const Mat4& viewProjMat, const Mat4& prevViewProjMat,
 								 CommandBufferPtr cmdb, SamplerPtr sampler, const RenderableQueueElement* begin,
-								 const RenderableQueueElement* end, U32 minLod, U32 maxLod)
+								 const RenderableQueueElement* end, U32 minLod, U32 maxLod, bool vrsMipBias)
 {
 	ANKI_ASSERT(begin && end && begin < end);
 
@@ -67,7 +67,7 @@ void RenderableDrawer::drawRange(Pass pass, const Mat4& viewMat, const Mat4& vie
 	ctx.m_queueCtx.m_stagingGpuAllocator = &m_r->getStagingGpuMemory();
 	ctx.m_queueCtx.m_commandBuffer = cmdb;
 	ctx.m_queueCtx.m_sampler = sampler;
-	ctx.m_queueCtx.m_key = RenderingKey(pass, 0, 1, false, false);
+	ctx.m_queueCtx.m_key = RenderingKey(pass, 0, 1, false, false, vrsMipBias);
 	ctx.m_queueCtx.m_debugDraw = false;
 	ctx.m_queueCtx.m_globalUniforms.m_buffer = globalUniformsToken.m_buffer;
 	ctx.m_queueCtx.m_globalUniforms.m_offset = globalUniformsToken.m_offset;

--- a/AnKi/Renderer/Drawer.h
+++ b/AnKi/Renderer/Drawer.h
@@ -33,7 +33,8 @@ public:
 
 	void drawRange(Pass pass, const Mat4& viewMat, const Mat4& viewProjMat, const Mat4& prevViewProjMat,
 				   CommandBufferPtr cmdb, SamplerPtr sampler, const RenderableQueueElement* begin,
-				   const RenderableQueueElement* end, U32 minLod = 0, U32 maxLod = MAX_LOD_COUNT - 1);
+				   const RenderableQueueElement* end, U32 minLod = 0, U32 maxLod = MAX_LOD_COUNT - 1,
+				   bool vrsMipBias = false);
 
 private:
 	Renderer* m_r;

--- a/AnKi/Renderer/GBuffer.cpp
+++ b/AnKi/Renderer/GBuffer.cpp
@@ -154,7 +154,7 @@ void GBuffer::runInThread(const RenderingContext& ctx, RenderPassWorkContext& rg
 										ctx.m_matrices.m_jitter * ctx.m_prevMatrices.m_viewProjection, cmdb,
 										m_r->getSamplers().m_trilinearRepeatAnisoResolutionScalingBias,
 										ctx.m_renderQueue->m_renderables.getBegin() + colorStart,
-										ctx.m_renderQueue->m_renderables.getBegin() + colorEnd);
+										ctx.m_renderQueue->m_renderables.getBegin() + colorEnd, 0U, 2U, enableVrs);
 	}
 }
 

--- a/AnKi/Resource/MaterialResource.h
+++ b/AnKi/Resource/MaterialResource.h
@@ -44,6 +44,7 @@ enum class BuiltinMutatorId : U8
 	LOD,
 	BONES,
 	VELOCITY,
+	VRS,
 
 	COUNT,
 	FIRST = 0
@@ -435,7 +436,7 @@ private:
 	U32 m_globalUniformsUboBinding = MAX_U32;
 
 	/// Matrix of variants.
-	mutable Array5d<MaterialVariant, U(Pass::COUNT), MAX_LOD_COUNT, 2, 2, 2> m_variantMatrix;
+	mutable Array6d<MaterialVariant, U(Pass::COUNT), MAX_LOD_COUNT, 2, 2, 2, 2> m_variantMatrix;
 	mutable RWMutex m_variantMatrixMtx;
 
 	DynamicArray<MaterialVariable> m_vars;

--- a/AnKi/Resource/RenderingKey.h
+++ b/AnKi/Resource/RenderingKey.h
@@ -26,24 +26,25 @@ enum class Pass : U8
 class RenderingKey
 {
 public:
-	RenderingKey(Pass pass, U32 lod, U32 instanceCount, Bool skinned, Bool velocity)
+	RenderingKey(Pass pass, U32 lod, U32 instanceCount, Bool skinned, Bool velocity, Bool vrs)
 		: m_pass(pass)
 		, m_lod(U8(lod))
 		, m_instanceCount(U8(instanceCount))
 		, m_skinned(skinned)
 		, m_velocity(velocity)
+		, m_vrs(vrs)
 	{
 		ANKI_ASSERT(instanceCount <= MAX_INSTANCE_COUNT && instanceCount != 0);
 		ANKI_ASSERT(lod <= MAX_LOD_COUNT);
 	}
 
 	RenderingKey()
-		: RenderingKey(Pass::GB, 0, 1, false, false)
+		: RenderingKey(Pass::GB, 0, 1, false, false, false)
 	{
 	}
 
 	RenderingKey(const RenderingKey& b)
-		: RenderingKey(b.m_pass, b.m_lod, b.m_instanceCount, b.m_skinned, b.m_velocity)
+		: RenderingKey(b.m_pass, b.m_lod, b.m_instanceCount, b.m_skinned, b.m_velocity, b.m_vrs)
 	{
 	}
 
@@ -56,7 +57,7 @@ public:
 	Bool operator==(const RenderingKey& b) const
 	{
 		return m_pass == b.m_pass && m_lod == b.m_lod && m_instanceCount == b.m_instanceCount
-			   && m_skinned == b.m_skinned && m_velocity == b.m_velocity;
+			   && m_skinned == b.m_skinned && m_velocity == b.m_velocity && m_vrs == b.m_vrs;
 	}
 
 	Pass getPass() const
@@ -111,12 +112,23 @@ public:
 		m_velocity = v;
 	}
 
+	Bool hasVrs() const
+	{
+		return m_vrs;
+	}
+
+	void setVrs(Bool v)
+	{
+		m_vrs = v;
+	}
+
 private:
 	Pass m_pass;
 	U8 m_lod;
 	U8 m_instanceCount;
 	Bool m_skinned : 1;
 	Bool m_velocity : 1;
+	Bool m_vrs : 1;
 };
 
 template<>

--- a/AnKi/Shaders/GBufferGeneric.ankiprog
+++ b/AnKi/Shaders/GBufferGeneric.ankiprog
@@ -8,6 +8,7 @@
 #pragma anki mutator ANKI_VELOCITY 0 1
 #pragma anki mutator ANKI_PASS 0 2 3
 #pragma anki mutator ANKI_BONES 0 1
+#pragma anki mutator ANKI_VRS 0 1
 #pragma anki mutator DIFFUSE_TEX 0 1
 #pragma anki mutator SPECULAR_TEX 0 1
 #pragma anki mutator ROUGHNESS_TEX 0 1
@@ -279,6 +280,10 @@ void main()
 
 #pragma anki start frag
 
+#if ANKI_VRS
+#	extension GL_EXT_fragment_shading_rate : require
+#endif
+
 #if REALLY_USING_PARALLAX
 Vec2 computeTextureCoordParallax(texture2D heightMap, sampler sampl, Vec2 uv, F32 heightMapScale)
 {
@@ -351,10 +356,10 @@ Vec2 computeTextureCoordParallax(texture2D heightMap, sampler sampl, Vec2 uv, F3
 
 // Do normal mapping
 #if ANKI_PASS == PASS_GB
-ANKI_RP Vec3 readNormalFromTexture(ANKI_RP texture2D map, sampler sampl, highp Vec2 texCoords)
+ANKI_RP Vec3 readNormalFromTexture(ANKI_RP texture2D map, sampler sampl, highp Vec2 texCoords, F32 bias)
 {
 	// First read the texture
-	const ANKI_RP Vec3 nAtTangentspace = normalize((texture(map, sampl, texCoords).rgb - 0.5) * 2.0);
+	const ANKI_RP Vec3 nAtTangentspace = normalize((texture(map, sampl, texCoords, bias).rgb - 0.5) * 2.0);
 
 	const ANKI_RP Vec3 n = normalize(in_normal);
 	const ANKI_RP Vec3 t = normalize(in_tangent);
@@ -384,44 +389,58 @@ void main()
 	const Vec2 uv = in_uv;
 #	endif
 
+	F32 bias = 0.0;
+#	if ANKI_VRS
+	if((gl_ShadingRateEXT & gl_ShadingRateFlag2VerticalPixelsEXT) != 0
+	   || (gl_ShadingRateEXT & gl_ShadingRateFlag2HorizontalPixelsEXT) != 0)
+	{
+		bias = -1.0;
+	}
+	else if((gl_ShadingRateEXT & gl_ShadingRateFlag4VerticalPixelsEXT) != 0
+			|| (gl_ShadingRateEXT & gl_ShadingRateFlag4HorizontalPixelsEXT) != 0)
+	{
+		bias = -2.0;
+	}
+#	endif
+
 #	if defined(USING_DIFF_TEX)
 #		if ALPHA_TEST
-	const ANKI_RP Vec4 diffColorA = texture(u_diffTex, u_ankiGlobalSampler, uv);
+	const ANKI_RP Vec4 diffColorA = texture(u_diffTex, u_ankiGlobalSampler, uv, bias);
 	doAlphaText(diffColorA.a);
 	const ANKI_RP Vec3 diffColor = diffColorA.rgb;
 #		else
-	const ANKI_RP Vec3 diffColor = texture(u_diffTex, u_ankiGlobalSampler, uv).rgb;
+	const ANKI_RP Vec3 diffColor = texture(u_diffTex, u_ankiGlobalSampler, uv, bias).rgb;
 #		endif
 #	else
 	const ANKI_RP Vec3 diffColor = u_ankiPerDraw.m_diffColor;
 #	endif
 
 #	if defined(USING_SPECULAR_TEX)
-	const ANKI_RP Vec3 specColor = texture(u_specTex, u_ankiGlobalSampler, uv).rgb;
+	const ANKI_RP Vec3 specColor = texture(u_specTex, u_ankiGlobalSampler, uv, bias).rgb;
 #	else
 	const ANKI_RP Vec3 specColor = u_ankiPerDraw.m_specColor;
 #	endif
 
 #	if defined(USING_ROUGHNESS_TEX)
-	const ANKI_RP F32 roughness = texture(u_roughnessTex, u_ankiGlobalSampler, uv).g;
+	const ANKI_RP F32 roughness = texture(u_roughnessTex, u_ankiGlobalSampler, uv, bias).g;
 #	else
 	const ANKI_RP F32 roughness = u_ankiPerDraw.m_roughness;
 #	endif
 
 #	if defined(USING_METALLIC_TEX)
-	const ANKI_RP F32 metallic = texture(u_metallicTex, u_ankiGlobalSampler, uv).b;
+	const ANKI_RP F32 metallic = texture(u_metallicTex, u_ankiGlobalSampler, uv, bias).b;
 #	else
 	const ANKI_RP F32 metallic = u_ankiPerDraw.m_metallic;
 #	endif
 
 #	if defined(USING_NORMAL_TEX)
-	const ANKI_RP Vec3 normal = readNormalFromTexture(u_normalTex, u_ankiGlobalSampler, uv);
+	const ANKI_RP Vec3 normal = readNormalFromTexture(u_normalTex, u_ankiGlobalSampler, uv, bias);
 #	else
 	const ANKI_RP Vec3 normal = normalize(in_normal);
 #	endif
 
 #	if defined(USING_EMISSIVE_TEX)
-	const ANKI_RP Vec3 emission = texture(u_emissiveTex, u_ankiGlobalSampler, uv).rgb;
+	const ANKI_RP Vec3 emission = texture(u_emissiveTex, u_ankiGlobalSampler, uv, bias).rgb;
 #	else
 	const ANKI_RP Vec3 emission = u_ankiPerDraw.m_emission;
 #	endif

--- a/AnKi/Util/Array.h
+++ b/AnKi/Util/Array.h
@@ -201,6 +201,10 @@ using Array4d = Array<Array<Array<Array<T, L>, K>, J>, I>;
 /// 5D Array. @code Array5d<X, 10, 2, 3, 4, 5> a; @endcode is equivelent to @code X a[10][2][3][4][5]; @endcode
 template<typename T, PtrSize I, PtrSize J, PtrSize K, PtrSize L, PtrSize M>
 using Array5d = Array<Array<Array<Array<Array<T, M>, L>, K>, J>, I>;
+
+/// 6D Array. @code Array6d<X, 10, 2, 3, 4, 5> a; @endcode is equivelent to @code X a[10][2][3][4][5][6]; @endcode
+template<typename T, PtrSize I, PtrSize J, PtrSize K, PtrSize L, PtrSize M, PtrSize N>
+using Array6d = Array<Array<Array<Array<Array<Array<T, N>, M>, L>, K>, J>, I>;
 /// @}
 
 } // end namespace anki


### PR DESCRIPTION
Use a mip bias to compensate for VRS affecting derivatives during the Gbuffer pass. The mip bias is determined based on the fragment shading rate (gl_ShadingRateEXT).