### PR TITLE
Fixes for skinning

### DIFF
--- a/AnKi/Resource/SkeletonResource.cpp
+++ b/AnKi/Resource/SkeletonResource.cpp
@@ -71,13 +71,7 @@ Error SkeletonResource::load(const ResourceFilename& filename, [[maybe_unused]] 
 		{
 			boneParents.pushBack("");
 
-			if(m_rootBoneIdx != MAX_U32)
-			{
-				ANKI_RESOURCE_LOGE("Skeleton cannot have more than one root nodes");
-				return Error::USER_DATA;
-			}
-
-			m_rootBoneIdx = boneCount;
+			m_rootBonesIdxs.emplaceBack(getAllocator(), boneCount);
 		}
 
 		// Advance

--- a/AnKi/Resource/SkeletonResource.h
+++ b/AnKi/Resource/SkeletonResource.h
@@ -14,7 +14,7 @@ namespace anki {
 /// @addtogroup resource
 /// @{
 
-const U32 MAX_CHILDREN_PER_BONE = 8;
+const U32 MAX_CHILDREN_PER_BONE = 12;
 
 /// Skeleton bone
 class Bone
@@ -123,14 +123,19 @@ public:
 		return nullptr;
 	}
 
-	const Bone& getRootBone() const
+	const Bone& getRootBoneAt(const U32 idx) const
 	{
-		return m_bones[m_rootBoneIdx];
+		return m_bones[m_rootBonesIdxs[idx]];
+	}
+
+	const U32 getRootBoneCount() const
+	{
+		return m_rootBonesIdxs.getSize();
 	}
 
 private:
 	DynamicArray<Bone> m_bones;
-	U32 m_rootBoneIdx = MAX_U32;
+	DynamicArray<U32> m_rootBonesIdxs;
 };
 /// @}
 

--- a/AnKi/Scene/Components/SkinComponent.cpp
+++ b/AnKi/Scene/Components/SkinComponent.cpp
@@ -79,7 +79,7 @@ Error SkinComponent::update(SceneComponentUpdateInfo& info, Bool& updated)
 	Vec4 minExtend(MAX_F32, MAX_F32, MAX_F32, 0.0f);
 	Vec4 maxExtend(MIN_F32, MIN_F32, MIN_F32, 0.0f);
 
-	BitSet<128> bonesAnimated(false);
+	BitSet<256> bonesAnimated(false);
 
 	for(Track& track : m_tracks)
 	{
@@ -176,7 +176,11 @@ Error SkinComponent::update(SceneComponentUpdateInfo& info, Bool& updated)
 		m_crntBoneTrfs = m_crntBoneTrfs ^ 1;
 
 		// Walk the bone hierarchy to add additional transforms
-		visitBones(m_skeleton->getRootBone(), Mat4::getIdentity(), bonesAnimated, minExtend, maxExtend);
+		for(U32 i = 0; i < m_skeleton->getRootBoneCount(); ++i)
+		{
+			visitBones(m_skeleton->getRootBoneAt(i), Mat4::getIdentity(), bonesAnimated, minExtend,
+					   maxExtend);
+		}
 
 		const Vec4 E(EPSILON, EPSILON, EPSILON, 0.0f);
 		m_boneBoundingVolume.setMin(minExtend - E);
@@ -192,7 +196,7 @@ Error SkinComponent::update(SceneComponentUpdateInfo& info, Bool& updated)
 	return Error::NONE;
 }
 
-void SkinComponent::visitBones(const Bone& bone, const Mat4& parentTrf, const BitSet<128>& bonesAnimated,
+void SkinComponent::visitBones(const Bone& bone, const Mat4& parentTrf, const BitSet<256>& bonesAnimated,
 							   Vec4& minExtend, Vec4& maxExtend)
 {
 	Mat4 outMat;

--- a/AnKi/Scene/Components/SkinComponent.h
+++ b/AnKi/Scene/Components/SkinComponent.h
@@ -108,7 +108,7 @@ private:
 	U8 m_crntBoneTrfs = 0;
 	U8 m_prevBoneTrfs = 1;
 
-	void visitBones(const Bone& bone, const Mat4& parentTrf, const BitSet<128, U8>& bonesAnimated, Vec4& minExtend,
+	void visitBones(const Bone& bone, const Mat4& parentTrf, const BitSet<256, U8>& bonesAnimated, Vec4& minExtend,
 					Vec4& maxExtend);
 };
 /// @}


### PR DESCRIPTION
Gltf 2.0 spec says that every bone must have a direct/indirect parent, so a bone's parent might not necessarily be another bone which allows the skin to have several root bones. See one of Mixamo's downloaded skeletons for an example of this.
GltfImporter will already create the node hierarchy so this "indirect parent" connection will implicitly exist in the current workflow, so the changes in this PR just enable the usecases when the skin contains several bones with an indirect root parent