### PR TITLE
PushConstants bug fix

### DIFF
--- a/AnKi/Renderer/Scale.cpp
+++ b/AnKi/Renderer/Scale.cpp
@@ -466,18 +466,18 @@ void Scale::runTonemapping(RenderPassWorkContext& rgraphCtx)
 
 	rgraphCtx.bindImage(0, 2, m_r->getTonemapping().getRt());
 
-	class
-	{
-	public:
-		Vec2 m_viewportSizeOverOne;
-		UVec2 m_viewportSize;
-	} pc;
-	pc.m_viewportSizeOverOne = 1.0f / Vec2(m_r->getPostProcessResolution());
-	pc.m_viewportSize = m_r->getPostProcessResolution();
-	cmdb->setPushConstants(&pc, sizeof(pc));
 
 	if(preferCompute)
 	{
+		class
+		{
+		public:
+			Vec2 m_viewportSizeOverOne;
+			UVec2 m_viewportSize;
+		} pc;
+		pc.m_viewportSizeOverOne = 1.0f / Vec2(m_r->getPostProcessResolution());
+		pc.m_viewportSize = m_r->getPostProcessResolution();
+		cmdb->setPushConstants(&pc, sizeof(pc));
 		rgraphCtx.bindImage(0, 3, outRt);
 
 		dispatchPPCompute(cmdb, 8, 8, m_r->getPostProcessResolution().x(), m_r->getPostProcessResolution().y());


### PR DESCRIPTION
The Push Constants in the tonemap workload of Scale task are only used by the compute variant. Current state will assert when enabling the "ANKI_EXTRA_CHECKS=1" and using "RPreferCompute=0"

Repro: Just run with ANKI_EXTRA_CHECKS, RPreferCompute and using the GrUpscaler.
Fix: Only set the PushConstants when using Compute