### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/ThirdParty/ZLib/inflate.c
+++ b/ThirdParty/ZLib/inflate.c
@@ -763,9 +763,10 @@ int flush;
                 copy = state->length;
                 if (copy > have) copy = have;
                 if (copy) {
+                    len = state->head->extra_len - state->length;
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        len < state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function inflate() in `ThirdParty/ZLib/inflate.c`  sourced from [madler/zlib](https://github.com/madler/zlib). This issue, originally reported in [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2022-37434), was resolved in the repository via this commit https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!