### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/ThirdParty/Sdl2/src/render/opengles/SDL_render_gles.c
+++ b/ThirdParty/Sdl2/src/render/opengles/SDL_render_gles.c
@@ -368,6 +368,9 @@ GLES_CreateTexture(SDL_Renderer * renderer, SDL_Texture * texture)
     renderdata->glGenTextures(1, &data->texture);
     result = renderdata->glGetError();
     if (result != GL_NO_ERROR) {
+        if (texture->access == SDL_TEXTUREACCESS_STREAMING) {
+            SDL_free(data->pixels);
+        }
         SDL_free(data);
         return GLES_SetError("glGenTextures()", result);
     }


### PR DESCRIPTION
Hi Development Team,

I identified another potential vulnerability in a clone function GLES_CreateTexture() in `ThirdParty/Sdl2/src/render/opengles/SDL_render_gles.c` sourced from [libsdl-org/SDL](https://github.com/libsdl-org/SDL). This issue, originally reported in [CVE-2022-4743](https://nvd.nist.gov/vuln/detail/CVE-2022-4743), was resolved in the repository via this commit https://github.com/libsdl-org/SDL/commit/00b67f55727bc0944c3266e2b875440da132ce4b.

This PR applies the corresponding patch to handle potential null pointer dereference in this codebase.

Please review at your convenience. Thank you!